### PR TITLE
rtpi: update bug-report address

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 
-AC_INIT([librtpi], [0.0.1], [dvhart@infradead.org])
+AC_INIT([librtpi], [0.0.1], [https://github.com/linux-rt/librtpi/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_PROG_AR
 LT_INIT


### PR DESCRIPTION
Darren Hart has transitioned the librtpi maintainership to me. Replace his bug-report email address with a link to the updated project GitHub issues page.

This will show up in test logs as:
```
  ============================================================================
  Testsuite summary for librtpi 0.0.1
  ============================================================================
  # TOTAL: 4
  # PASS:  2
  # SKIP:  0
  # XFAIL: 0
  # FAIL:  2
  # XPASS: 0
  # ERROR: 0
  ============================================================================
  See tests/test-suite.log
  Please report to https://github.com/linux-rt/librtpi/issues
  ============================================================================
```